### PR TITLE
ヘッダー・戻り動線の整理

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Link } from "gatsby";
+import stylesOrg from '../styles/index.module.css';
+
+
+export default () => {
+  return (
+      <header className={stylesOrg.header}>
+      <Link to="/">Idea Factory XYZ</Link>
+      </header>
+  )
+}

--- a/src/components/description.js
+++ b/src/components/description.js
@@ -3,15 +3,18 @@ import ArrowBack from "../components/arrow_left";
 import ArrowForward from "../components/arrow_right";
 import styles from '../scss/custom.module.scss';
 import { Helmet } from "react-helmet";
+import Header from '../components/Header';
 
 
 export default (props) => {
   return (
-      <div className={`${styles.mt2} ${styles.container} ${styles.pb5} ${styles.mb5}`}>
+    <div>
       <Helmet>
       <meta charSet="utf-8" />
       <title>{`${props.title} - アイデアファクトリー`}</title>
       </Helmet>
+      <Header />
+      <div className={`${styles.mt4} ${styles.container} ${styles.pb5} ${styles.mb5}`}>
       <div className={styles.row}>
       <div className={styles.colLg}></div>
       <div className={styles.colLg8}>
@@ -21,6 +24,7 @@ export default (props) => {
       <div className={`${styles.fixedBottom} ${styles.dFlex} ${styles.justifyContentAround} ${styles.my5}`}>
       <ArrowBack path="/" />
       <ArrowForward path={props.to} />
+      </div>
       </div>
       </div>
       </div>

--- a/src/pages/books.js
+++ b/src/pages/books.js
@@ -2,6 +2,7 @@ import React from "react";
 import styles from '../scss/custom.module.scss';
 import { Helmet } from "react-helmet";
 import Header from '../components/Header';
+import ArrowBack from "../components/arrow_left";
 
 
 export default () => {
@@ -46,6 +47,9 @@ export default () => {
       </ul>
       </div>
       <div className={styles.colLg}></div>
+      <div className={`${styles.fixedBottom} ${styles.dFlex} ${styles.justifyContentAround} ${styles.my5}`}>
+      <ArrowBack path="/" />
+      </div>
       </div>
       </div>
       </div>

--- a/src/pages/books.js
+++ b/src/pages/books.js
@@ -1,19 +1,22 @@
 import React from "react";
 import styles from '../scss/custom.module.scss';
 import { Helmet } from "react-helmet";
+import Header from '../components/Header';
 
 
 export default () => {
   return (
-      <div className={`${styles.mt2} ${styles.container}`}>
+    <div>
       <Helmet>
       <meta charSet="utf-8" />
       <title>本サイトで紹介している書籍、ほか - アイデアファクトリー</title>
       </Helmet>
-      <h1>本サイトで紹介している書籍、ほか - アイデアファクトリー</h1>
+      <Header />
+      <div className={`${styles.mt4} ${styles.container}`}>
       <div className={styles.row}>
       <div className={styles.colLg}></div>
       <div className={styles.colLg8}>
+      <h1>本サイトで紹介している書籍、ほか</h1>
       <h2>マーケティング編</h2>
       <ul>
       <li><a href="https://amzn.to/2xf4XvL" target="_blank" rel="noopener noreferrer">コトラーのマーケティング・コンセプト</a></li>
@@ -43,6 +46,7 @@ export default () => {
       </ul>
       </div>
       <div className={styles.colLg}></div>
+      </div>
       </div>
       </div>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ export default () => {
       <Link to="/">Idea Factory XYZ</Link>
       </header>
 
-      <div className={`${styles.mt2} ${styles.container}`}>
+      <div className={`${styles.mt4} ${styles.container}`}>
       <div className={styles.row}>
         <div className={styles.colLg}></div>
         <div className={styles.colLg8}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,8 +14,8 @@ export default () => {
       </Helmet>
 
       <header className={stylesOrg.header}>
-      Idea Factory XYZ
-    </header>
+      <Link to="/">Idea Factory XYZ</Link>
+      </header>
 
       <div className={`${styles.mt2} ${styles.container}`}>
       <div className={styles.row}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,7 @@ import { Link } from "gatsby";
 import styles from '../scss/custom.module.scss';
 import { Helmet } from "react-helmet";
 import stylesOrg from '../styles/index.module.css';
-
+import Header from '../components/Header';
 
 export default () => {
   return (
@@ -13,9 +13,7 @@ export default () => {
       <title>アイデアファクトリー</title>
       </Helmet>
 
-      <header className={stylesOrg.header}>
-      <Link to="/">Idea Factory XYZ</Link>
-      </header>
+      <Header />
 
       <div className={`${styles.mt4} ${styles.container}`}>
       <div className={styles.row}>

--- a/src/styles/index.module.css
+++ b/src/styles/index.module.css
@@ -4,6 +4,10 @@
   padding: 10px 0 10px 18px;
 }
 
+.header a {
+  color: white;
+}
+
 .headline {
   font-family: initial;
   font-weight: bolder;


### PR DESCRIPTION
https://github.com/t-morisawa/idea-factory-xyz/issues/29

 - ヘッダー・戻り動線の追加
 - アプリページへの戻り動線・ヘッダーは見送り
    - 余計なUIを追加したくない
    - 使っているCSSフレームワークが違うので入れたくない