### PR TITLE
Google Fontsを捨てる

### DIFF
--- a/src/scss/custom.module.scss
+++ b/src/scss/custom.module.scss
@@ -1,3 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Sawarabi+Mincho');
-$font-family-base: 'Sawarabi Mincho', sans-serif;
 @import "node_modules/bootstrap/scss/bootstrap.scss";


### PR DESCRIPTION
https://github.com/t-morisawa/idea-factory-xyz/issues/51

# before
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/13075237/82723201-09ec4600-9d08-11ea-896f-24235fb1c6c2.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/13075237/82723208-183a6200-9d08-11ea-89a2-e502a93be798.png">

# after
![スクリーンショット 2020-05-23 15 10 52](https://user-images.githubusercontent.com/13075237/82723194-fd67ed80-9d07-11ea-8197-b432b41eb0d9.jpg)
![スクリーンショット 2020-05-23 15 11 01](https://user-images.githubusercontent.com/13075237/82723196-01940b00-9d08-11ea-844d-8b4ddad43a16.jpg)
